### PR TITLE
feat(import): Set ID for Imported Data

### DIFF
--- a/simple-firestore-import.py
+++ b/simple-firestore-import.py
@@ -22,7 +22,10 @@ def import_data(service_account_key_path, data_file, collection_name):
 
         doc_ref = db.collection(collection_name)
         for datum in data:
-            doc_ref.add(datum)
+            if datum.get("id") or datum.get("_id"):
+                doc_ref.document(datum.get("id")).set(datum)
+            else:
+                doc_ref.add(datum)
             print("Added: {}".format(datum))
 
     except Exception as error:


### PR DESCRIPTION
This pull request introduces a new feature to the Simple Firestore Import repository. The feature allows users to set a custom ID for the data being imported from json and yaml files into Firebase Cloud Firestore.

With this enhancement, users now have the flexibility to specify the unique identifier for each imported document, giving them more control over the data being added to their Firestore database.

By incorporating this feature, the Simple Firestore Import tool becomes even more versatile, enabling seamless data importation with customizable document IDs.

This pull request addresses the following user request or issue:
- Allow users to set custom IDs for imported data

Thank you for reviewing this pull request. Your feedback and suggestions are welcome.

Please let me know if you have any questions.

Kind regards,
@JandroMejia97